### PR TITLE
Add integration coverage and document Zustand store

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,7 +24,7 @@ import {
   TASK_CATEGORY_MAP
 } from './constants';
 import { useAppStore } from './store/appStore';
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/react/shallow';
 
 
 /**
@@ -62,7 +62,7 @@ const App: React.FC = () => {
     handleTaskSelect: storeHandleTaskSelect,
     toggleCompletionEnhancement,
   } = useAppStore(
-    (state) => ({
+    useShallow((state) => ({
       uploadedFiles: state.uploadedFiles,
       processedFilesContent: state.processedFilesContent,
       selectedTask: state.selectedTask,
@@ -91,8 +91,7 @@ const App: React.FC = () => {
       handleFilesUploaded: state.handleFilesUploaded,
       handleTaskSelect: state.handleTaskSelect,
       toggleCompletionEnhancement: state.toggleCompletionEnhancement,
-    }),
-    shallow
+    })),
   );
 
   const handleFilesUploaded = useCallback((files: File[]) => {

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import App from '../App';
+import { processFilesForGemini } from '../services/fileReaderService';
+import { processTextsWithGemini } from '../services/geminiService';
+import { useAppStore } from '../store/appStore';
+import { ProcessedFile, TaskType, GeminiServiceResponse } from '../types';
+
+const mockUseDropzone = vi.fn();
+
+type DropzoneOptions = {
+  onDrop: (
+    acceptedFiles: File[],
+    rejectedFiles: Array<{ file: File; errors: Array<{ code: string; message: string }> }>,
+  ) => void;
+};
+
+vi.mock('react-dropzone', () => ({
+  useDropzone: (options: unknown) => mockUseDropzone(options),
+}));
+
+vi.mock('../services/fileReaderService', () => ({
+  processFilesForGemini: vi.fn(),
+}));
+
+vi.mock('../services/geminiService', () => ({
+  processTextsWithGemini: vi.fn(),
+}));
+
+const mockedProcessFilesForGemini = vi.mocked(processFilesForGemini);
+const mockedProcessTextsWithGemini = vi.mocked(processTextsWithGemini);
+
+const resetStoreState = () => {
+  useAppStore.setState({
+    uploadedFiles: [],
+    processedFilesContent: [],
+    selectedTask: null,
+    specialRequirements: '',
+    additionalInfo: '',
+    completionScope: '',
+    selectedCompletionEnhancements: [],
+    previousCompletionContext: null,
+    usePreviousContextForCompletion: false,
+    geminiResult: null,
+    error: null,
+    submissionError: null,
+    isLoading: false,
+    apiKeyPresent: true,
+  });
+};
+
+describe('App integration workflow', () => {
+  let latestOptions: DropzoneOptions | null = null;
+
+  beforeEach(() => {
+    latestOptions = null;
+    resetStoreState();
+    mockUseDropzone.mockReset();
+    mockedProcessFilesForGemini.mockReset();
+    mockedProcessTextsWithGemini.mockReset();
+
+    mockUseDropzone.mockImplementation((options: DropzoneOptions) => {
+      latestOptions = options;
+      return {
+        getRootProps: () => ({}),
+        getInputProps: () => ({}),
+        isDragActive: false,
+      };
+    });
+  });
+
+  it('handles uploading, task selection, and submission with loader feedback', async () => {
+    const processedFiles: ProcessedFile[] = [
+      {
+        name: 'script.txt',
+        mimeType: 'text/plain',
+        content: 'المحتوى المعالج',
+        isBase64: false,
+        size: 42,
+      },
+    ];
+
+    mockedProcessFilesForGemini.mockResolvedValue(processedFiles);
+
+    let resolveSubmission: ((value: GeminiServiceResponse) => void) | undefined;
+    const submissionPromise = new Promise<GeminiServiceResponse>((resolve) => {
+      resolveSubmission = resolve;
+    });
+    mockedProcessTextsWithGemini.mockReturnValue(submissionPromise);
+
+    render(<App />);
+
+    expect(latestOptions).not.toBeNull();
+
+    const file = new File(['Scene'], 'script.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      latestOptions?.onDrop([file], []);
+    });
+
+    await waitFor(() => {
+      expect(mockedProcessFilesForGemini).toHaveBeenCalledWith([file]);
+    });
+
+    await screen.findByText('script.txt');
+
+    const taskButton = (await screen.findByText('تحليل نقدي')).closest('button');
+    expect(taskButton).not.toBeNull();
+    fireEvent.click(taskButton!);
+
+    const submitButtons = screen.getAllByRole('button', { name: 'تحليل نقدي' });
+    const submitButton = submitButtons[submitButtons.length - 1];
+
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    expect(await screen.findByText('جاري تحليل نقدي...')).toBeInTheDocument();
+
+    expect(resolveSubmission).toBeDefined();
+    await act(async () => {
+      resolveSubmission!({ data: null, rawText: 'استجابة' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('جاري تحليل نقدي...')).not.toBeInTheDocument();
+    });
+
+    expect(mockedProcessTextsWithGemini).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskType: TaskType.ANALYSIS,
+        processedFiles,
+      }),
+    );
+  });
+});

--- a/components/ErrorMessage.tsx
+++ b/components/ErrorMessage.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 
 type ErrorTone = 'error' | 'warning';
 
+/**
+ * Props for the standardised error banner used across the application.
+ *
+ * @property title - Short headline describing the failure category.
+ * @property description - Detailed explanation surfaced to the user.
+ * @property tone - Optional styling hint (error vs warning palette).
+ * @property className - Additional utility classes forwarded to the container.
+ */
 interface ErrorMessageProps {
   title: string;
   description: string;

--- a/components/TaskSelector.tsx
+++ b/components/TaskSelector.tsx
@@ -9,7 +9,13 @@ import {
 } from '../constants'; // Added ClipboardDocumentIcon to imports
 import { ENHANCED_TASK_DESCRIPTIONS } from '../ai/orchestration';
 
-
+/**
+ * Props controlling the task selector menu that allows the user to pick one
+ * analytical or creative workflow at a time.
+ *
+ * @property selectedTask - Currently highlighted task, or `null` when nothing is chosen.
+ * @property onTaskSelect - Callback fired when the user activates a different task option.
+ */
 interface TaskSelectorProps {
   selectedTask: TaskType | null;
   onTaskSelect: (taskType: TaskType) => void;

--- a/services/__tests__/geminiService.test.ts
+++ b/services/__tests__/geminiService.test.ts
@@ -79,6 +79,27 @@ describe('constructPromptParts', () => {
     const fileSection = parts.find((part) => 'text' in part && part.text?.includes('--- الملف المقدم 1')) as Part | undefined;
     expect(fileSection?.text).toContain(baseFile.name);
   });
+
+  it('gracefully handles missing optional user configuration', () => {
+    const parts = constructPromptParts({
+      processedFiles: [baseFile],
+      taskType: TaskType.ANALYSIS,
+      specialRequirements: '',
+      additionalInfo: '',
+    });
+
+    const requirementsSection = parts.find(
+      (part) => 'text' in part && part.text?.includes('## مواصفات المستخدم الإضافية'),
+    ) as Part | undefined;
+
+    expect(requirementsSection).toBeDefined();
+    expect(requirementsSection?.text).toContain('لم يتم تقديم متطلبات محددة');
+
+    const previousContextSection = parts.find(
+      (part) => 'text' in part && part.text?.includes('## سياق الاستكمال السابق'),
+    );
+    expect(previousContextSection).toBeUndefined();
+  });
 });
 
 describe('processTextsWithGemini', () => {

--- a/store/appStore.ts
+++ b/store/appStore.ts
@@ -7,38 +7,82 @@ import {
 } from '../types';
 import { TASKS_REQUIRING_COMPLETION_SCOPE } from '../constants';
 
+/**
+ * Canonical shape of the application-wide Zustand store.
+ *
+ * Each property is intentionally documented so maintainers can quickly identify
+ * where workflow-specific state lives and which actions are responsible for
+ * mutating it. This significantly eases reasoning about complex UI flows.
+ */
 interface AppStoreState {
+  /** Raw files staged by the user prior to preprocessing. */
   uploadedFiles: File[];
+  /** Normalised representations of the uploaded assets that Gemini can consume. */
   processedFilesContent: ProcessedFile[];
+  /** Currently selected task identifier that drives prompt construction. */
   selectedTask: TaskType | null;
+  /** Free-form instructions provided by the user to tweak Gemini's behaviour. */
   specialRequirements: string;
+  /** Supplemental metadata describing the project or desired tone. */
   additionalInfo: string;
+  /** Scope field required for iterative completion oriented tasks. */
   completionScope: string;
+  /** Optional completion enhancement modules toggled by the user. */
   selectedCompletionEnhancements: TaskType[];
+  /** Snapshot of the previous completion output to enable iterative workflows. */
   previousCompletionContext: PreviousCompletionContext | null;
+  /** Whether the user opted to reuse the captured previous completion context. */
   usePreviousContextForCompletion: boolean;
+  /** Last response received from the Gemini service (success or error). */
   geminiResult: GeminiServiceResponse | null;
+  /** Human-readable error encountered during preprocessing. */
   error: string | null;
+  /** Human-readable error encountered during submission to Gemini. */
   submissionError: string | null;
+  /** Flag representing whether background work is currently running. */
   isLoading: boolean;
+  /** Whether a valid API key is available to drive Gemini interactions. */
   apiKeyPresent: boolean;
+  /** Stores the processed files after local preprocessing succeeds. */
   setProcessedFilesContent: (files: ProcessedFile[]) => void;
+  /** Persists updates to the free-form special requirements textarea. */
   setSpecialRequirements: (value: string) => void;
+  /** Persists updates to the supplemental information textarea. */
   setAdditionalInfo: (value: string) => void;
+  /** Updates the completion scope text field for completion tasks. */
   setCompletionScope: (value: string) => void;
+  /** Saves the latest Gemini response so downstream components can render it. */
   setGeminiResult: (result: GeminiServiceResponse | null) => void;
+  /** Captures preprocessing level errors to display inline in the UI. */
   setError: (message: string | null) => void;
+  /** Captures submission level errors to display inline in the UI. */
   setSubmissionError: (message: string | null) => void;
+  /** Toggles the loading indicator for both preprocessing and submission. */
   setIsLoading: (value: boolean) => void;
+  /** Signals whether the UI has access to a configured Gemini API key. */
   setApiKeyPresent: (value: boolean) => void;
+  /** Stores or clears the cached previous completion bundle. */
   setPreviousCompletionContext: (context: PreviousCompletionContext | null) => void;
+  /** Enables or disables reusing the cached completion context in the next prompt. */
   setUsePreviousContextForCompletion: (value: boolean) => void;
+  /** Sets the active completion enhancement modules. */
   setSelectedCompletionEnhancements: (enhancements: TaskType[]) => void;
+  /** Handles new uploads by refreshing staged files and resetting dependent state. */
   handleFilesUploaded: (files: File[]) => void;
+  /** Updates the currently selected task and clears incompatible settings. */
   handleTaskSelect: (task: TaskType) => void;
+  /** Adds or removes a specific completion enhancement module. */
   toggleCompletionEnhancement: (enhancement: TaskType) => void;
 }
 
+/**
+ * Shared Zustand store encapsulating the end-to-end workflow state for the app.
+ *
+ * The store centralises file handling, task configuration, Gemini responses and
+ * error reporting. Co-locating the logic guarantees that React components remain
+ * declarative and focus on presentation while hooks and actions orchestrate the
+ * complex multi-step interactions.
+ */
 export const useAppStore = create<AppStoreState>((set, get) => ({
   uploadedFiles: [],
   processedFilesContent: [],


### PR DESCRIPTION
## Summary
- document the Zustand app store and key UI props for maintainability
- add a full App workflow integration test and extend Gemini prompt unit tests
- update the App hook selection to use useShallow for React 19 compatibility

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd75a090f083288656abd9e2e563bb